### PR TITLE
fix: make PYENV_ROOT env relative

### DIFF
--- a/scripts.programs/pyenv.sh
+++ b/scripts.programs/pyenv.sh
@@ -13,6 +13,6 @@ fi
 
 
 echo "\n\n# pyenv configuration" >> $CLI_CONFIG_PROGRAMS_CONF
-echo "export PYENV_ROOT=\"$CLI_CONFIG_ROOT/programs/pyenv\"" >> $CLI_CONFIG_PROGRAMS_CONF
+echo 'export PYENV_ROOT="$CLI_CONFIG_ROOT/programs/pyenv"' >> $CLI_CONFIG_PROGRAMS_CONF
 echo 'export PATH="$PYENV_ROOT/bin:$PATH"\n' >> $CLI_CONFIG_PROGRAMS_CONF
 echo 'eval "$(pyenv init -)"' >> $CLI_CONFIG_PROGRAMS_CONF


### PR DESCRIPTION
moving the cloned repo was breaking pyenv. This fix should write the config for `PYENV` to be relative to `CLI_CONFIG_ROOT`. 

But you will have to re-create the `programs.conf.sh` file for now. Or just delete it and run the setup script again.