### PR TITLE
Improv: Dynamically figure out where cli-config is installed

### DIFF
--- a/profiles/default/.zshrc
+++ b/profiles/default/.zshrc
@@ -1,5 +1,5 @@
-CLI_CONFIG_ROOT=`pwd`
-CLI_CONFIG_THEME='M365Princess'
+CLI_CONFIG_ROOT=$(ls -la ~/.zshrc | sed "s/^.*\->//" | awk -F '/' 'NF{NF-=3}1' 'OFS=/' | xargs)
+CLI_CONFIG_THEME='pure'
 
 # loads cli-config env variables
 source $CLI_CONFIG_ROOT/src/scripts/env.sh

--- a/profiles/mrsauravsahu/.zshrc
+++ b/profiles/mrsauravsahu/.zshrc
@@ -1,5 +1,5 @@
-CLI_CONFIG_ROOT=`pwd`
-CLI_CONFIG_THEME='blue-owl'
+CLI_CONFIG_ROOT=$(ls -la ~/.zshrc | sed "s/^.*\->//" | awk -F '/' 'NF{NF-=3}1' 'OFS=/' | xargs)
+CLI_CONFIG_THEME='pure'
 
 # loads cli-config env variables
 source $CLI_CONFIG_ROOT/src/scripts/env.sh

--- a/src/defs/install.sh
+++ b/src/defs/install.sh
@@ -89,18 +89,9 @@ install () {
         # TODO: check if we are specifically on Ubuntu
         . $CLI_CONFIG_ROOT/src/scripts/os-specific-setup.ubuntu.sh
 
-        # set CLI_CONFIG_ROOT value in.zshrc files in profiles
-        for i in `find $CLI_CONFIG_ROOT/profiles | grep .zshrc$`; do
-            sed -i $SED_OPTIONS "s|CLI_CONFIG_ROOT=\`pwd\`|CLI_CONFIG_ROOT='$CLI_CONFIG_ROOT'|" $i
-        done
     elif [ $currentOs = "Darwin" ]; then
         # Log 'Mac huh'
         . $CLI_CONFIG_ROOT/src/scripts/os-specific-setup.darwin.sh
-
-        # set CLI_CONFIG_ROOT value in.zshrc files in profiles
-        for i in `find $CLI_CONFIG_ROOT/profiles | grep .zshrc$`; do
-            sed -i '' $SED_OPTIONS "s|CLI_CONFIG_ROOT=\`pwd\`|CLI_CONFIG_ROOT='$CLI_CONFIG_ROOT'|" $i
-        done
     else
         Log 'what realm is this?'
     fi


### PR DESCRIPTION
Note: If you already have installed cli-config, you might want to restore changes to the `.zshrc`'s first line which sets `$CLI_CONFIG_ROOT`.

No harm in not changing it. But moving cli-config location will break it. Use
```bash
CLI_CONFIG_ROOT=$(ls -la ~/.zshrc | sed "s/^.*\->//" | awk -F '/' 'NF{NF-=3}1' 'OFS=/' | xargs)
```

